### PR TITLE
Fix TypeScript compilation errors by escaping backticks in template literal

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -297,7 +297,7 @@ When performing operations:
 4. **Report** results clearly
 5. **Suggest** next steps if applicable
 
-**CRITICAL: For GitHub interactions, ALWAYS use `github_create_comment` or `github_reply_comment` to communicate responses back to users. Never generate text that doesn't get posted to GitHub.**
+**CRITICAL: For GitHub interactions, ALWAYS use \`github_create_comment\` or \`github_reply_comment\` to communicate responses back to users. Never generate text that doesn't get posted to GitHub.**
 
 ## 🚨 SAFETY PROTOCOLS
 - Never modify .env files or sensitive configuration


### PR DESCRIPTION
This PR fixes TypeScript compilation errors caused by unescaped backticks inside the `getRepoAgentSystemPrompt` template literal in `app/api/chat/route.ts`.

**Changes:**
- Escaped backticks in communication rules section
- Escaped backticks in critical note section

These backticks were being used for markdown code formatting but needed to be escaped since they appear inside a JavaScript template literal.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Escaped backticks in the getRepoAgentSystemPrompt template literal to fix TypeScript compilation errors and prevent build failures. Updated the critical GitHub interaction note to use escaped backticks so the prompt compiles and renders correctly.

<sup>Written for commit 832cfcfa38e3b259dceeac4b7953c22491541cf7. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

