### PR TITLE
Fix: Add issue/PR number context to AI messages

### DIFF
--- a/app/api/webhooks/github/handlers.ts
+++ b/app/api/webhooks/github/handlers.ts
@@ -44,7 +44,7 @@ export async function handleIssueEvent(payload: WebhookEvent) {
     // Prepare messages for chat API
     const messages = [{
       role: 'user' as const,
-      content: command || 'Please help me understand this issue.'
+      content: `Regarding issue #${issue.number}: ${command || 'Please help me understand this issue.'}`
     }];
 
     // Call the chat API - AI will use github_create_comment tool to respond directly


### PR DESCRIPTION
The webhook handler was not including the issue or PR number in the user message sent to the AI, causing the AI to use generic IDs instead of the actual issue/PR numbers when creating comments. This fix adds the context to the user message so the AI knows which issue/PR it's working with.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Include the issue number in the message built by the GitHub issue webhook handler. This ensures generated comments reference the correct issue instead of a generic ID.

<sup>Written for commit 8075789c835669d8c3b7f21fcef67c6476c80377. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

